### PR TITLE
Support for downloading gifs, videos, and file name formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ Requirements
 * python-twitter
 * requests
 * urllib3
+* datetime
 
 Installation
 ------------
@@ -108,3 +109,5 @@ The "twphotos" command accepts the following options:
                         exclude replies
   -s SIZE, --size SIZE  photo size (``large``, ``medium``, ``small`` and ``thumb``)
   -t TYPE, --type TYPE  timeline type (``user`` and ``favorites``)
+  -v, --video           enable downloading of videos and gifs (note that twitter converts gifs to mp4 video)
+  -f, --filenaming      enable file download naming to DATE_TIME_HANDLE_MEDIA-NUMBER.filetype

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-twitter
 requests
 urllib3
+datetime

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email='shichao.an@nyu.edu',
     url='https://github.com/shichao-an/twitter-photos',
     license='BSD',
-    install_requires=['python-twitter', 'requests', 'urllib3'],
+    install_requires=['python-twitter', 'requests', 'urllib3', 'datetime'],
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,

--- a/twphotos/cli.py
+++ b/twphotos/cli.py
@@ -27,5 +27,9 @@ def parse_args():
                         help='photo size')
     parser.add_argument('-t', '--type', choices=TIMELINE_TYPES,
                         help='timeline type')
+    parser.add_argument('-v', '--video', action='store_true',
+                        help='enable gif and video download')
+    parser.add_argument('-f', '--filenaming', action='store_true',
+                        help='use tweet time and handle for file naming')
     args = parser.parse_args()
     return args

--- a/twphotos/photos.py
+++ b/twphotos/photos.py
@@ -120,8 +120,9 @@ class TwitterPhotos(object):
                 m_num =0
                 for m in s.media:
                     m_dict = m.AsDict()
-                    post_time = datetime.datetime.strptime(s.created_at, "%a %b %d %H:%M:%S +0000 %Y").strftime("%y%m%d_%H%M%S")
-                    m_name = (post_time + "_" + s.user.screen_name + "_" + str(m_num))
+                    if s.created_at is not None:
+                        post_time = datetime.datetime.strptime(s.created_at, "%a %b %d %H:%M:%S +0000 %Y").strftime("%y%m%d_%H%M%S")
+                        m_name = (post_time + "_" + s.user.screen_name + "_" + str(m_num))
 
                     if self.video and (m_dict['type'] == ('animated_gif' or 'video')):
                         t = (m_dict['id'], m.video_info['variants'][0]['url'])

--- a/twphotos/photos.py
+++ b/twphotos/photos.py
@@ -120,18 +120,18 @@ class TwitterPhotos(object):
                 m_num =0
                 for m in s.media:
                     m_dict = m.AsDict()
-                    if s.created_at is not None:
+                    if hasattr(s, 'created_at'):
                         post_time = datetime.datetime.strptime(s.created_at, "%a %b %d %H:%M:%S +0000 %Y").strftime("%y%m%d_%H%M%S")
                         m_name = (post_time + "_" + s.user.screen_name + "_" + str(m_num))
 
-                    if self.video and (m_dict['type'] == ('animated_gif' or 'video')):
-                        t = (m_dict['id'], m.video_info['variants'][0]['url'])
-                        fetched_photos.append(t)
-                        self.download_names.append(m_name)
-                    elif m_dict['type'] == 'photo':
-                        t = (m_dict['id'], m_dict['media_url'])
-                        fetched_photos.append(t)
-                        self.download_names.append(m_name)
+                        if self.video and (m_dict['type'] == ('animated_gif' or 'video')):
+                            t = (m_dict['id'], m.video_info['variants'][0]['url'])
+                            fetched_photos.append(t)
+                            self.download_names.append(m_name)
+                        elif m_dict['type'] == 'photo':
+                            t = (m_dict['id'], m_dict['media_url'])
+                            fetched_photos.append(t)
+                            self.download_names.append(m_name)
                     m_num += 1
 
         if num is not None:

--- a/twphotos/utils.py
+++ b/twphotos/utils.py
@@ -2,9 +2,17 @@ import os
 import requests
 
 
-def download(media_url, size, outdir):
-    r = requests.get(media_url + ':' + size, stream=True)
-    bs = os.path.basename(media_url)
+def download(media_url, size, outdir, download_name, file_naming):
+    file_type = media_url[-3:]
+    if file_type == "mp4":
+        download_url = media_url
+    else:
+        download_url = media_url + ':' + size
+    r = requests.get(download_url, stream=True)
+    if file_naming:
+        bs = download_name + "." + file_type
+    else:
+        bs = os.path.basename(media_url)
     filename = os.path.join(outdir or '', bs)
     with open(filename, 'wb') as fd:
         for chunk in r.iter_content(chunk_size=1024):


### PR DESCRIPTION
Sorry if this is messy, I'm not too familiar with python or pull requests.

I added a `-v, --video` flag to include videos and gifs (which are converted to videos by twitter) to be downloaded. Not sure why but only some videos and gifs get downloaded with this method. Quick troubleshooting session seems to indicate it might be an issue with the Twitter API at the moment.

Added an `-f, --filenaming` flag to enable formatting file names by tweet date, time, twitter handle, and media number (for tweets with multiple images). This is what I added the `datetime` module for. E.g. 170126_162000_dannytaylor_0.mp4 instead of C2r0qBzUoAAGIpK.mp4.