### PR TITLE
Resolve #11 by adding support for original resolution photos

### DIFF
--- a/twphotos/photos.py
+++ b/twphotos/photos.py
@@ -132,7 +132,7 @@ class TwitterPhotos(object):
 
     def download(self, size=None):
         if size is None:
-            size = self.size or 'large'
+            size = self.size or 'orig'
         if size not in MEDIA_SIZES:
             raise Exception('Invalid media size %s' % size)
         for user in self.photos:
@@ -283,7 +283,7 @@ def main():
                              size=args.size,
                              exclude_replies=args.exclude_replies,
                              tl_type=args.type)
-    # Print only scree_name, tweet id and media_url
+    # Print only screen_name, tweet id and media_url
     if args.print:
         twphotos.get(silent=True)
         twphotos.print_urls()

--- a/twphotos/settings.py
+++ b/twphotos/settings.py
@@ -51,7 +51,7 @@ ACCESS_TOKEN_SECRET = _items.get(CREDENTIAL_NAMES[3])
 
 # Other settings
 COUNT_PER_GET = 200
-MEDIA_SIZES = ('large', 'medium', 'small', 'thumb')
+MEDIA_SIZES = ('orig','large', 'medium', 'small', 'thumb')
 PROGRESS_FORMATTER = \
     'Downloading %(media_url)s from %(user)s: %(index)d/%(total)d'
 NUM_THREADS = 8


### PR DESCRIPTION
This resolves issue #11 and supports downloading original resolution photos.  It also downloads original photos by default instead of downloading large photos by default.  